### PR TITLE
Use testhat 3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Suggests:
     knitr,
     rmarkdown,
     spelling,
-    testthat,
+    testthat (>= 3.0.0),
     ggcorrplot
 LinkingTo: 
     Rcpp,
@@ -61,4 +61,6 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
+Config/testthat/edition: 3
+Config/testthat/parallel: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # partition (development version)
-* Updated to testthat edition 3
+* Updated to testthat edition 3 (#22)
 
 # partition 0.1.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # partition (development version)
+* Updated to testthat edition 3
 
 # partition 0.1.2
 

--- a/R/simulate_block.R
+++ b/R/simulate_block.R
@@ -29,13 +29,14 @@
 simulate_block_data <- function(block_sizes, lower_corr, upper_corr, n, block_name = "block",
                              sep = "_", var_name = "x") {
   #  simulate length(block_sizes) blocks and bind them in a data.frame
-	sim_data <- purrr::map_dfc(
+	sim_data <- purrr::map(
 	  block_sizes,
 	  simulate_block,
 	  n = n,
 	  lower_corr = lower_corr,
 	  upper_corr = upper_corr
-	)
+	) %>%
+	  dplyr::bind_cols(.name_repair = "minimal")
 
 	#  create column names: `block_name`+`sep`+`var_name`+n
 	col_names <- purrr::map2(

--- a/tests/testthat/helper-df.R
+++ b/tests/testthat/helper-df.R
@@ -1,5 +1,3 @@
-context("test-helper-df")
-
 #  Data frames for testing. Produced on macOS by:
 #  set.seed(1234)
 #  df <- datapasta::tribble_paste(simulate_block_data(5, lower_corr = .5, upper_corr = .65, n = 100))

--- a/tests/testthat/test-mappings-and-scores-work.R
+++ b/tests/testthat/test-mappings-and-scores-work.R
@@ -3,12 +3,12 @@ prt <- partition(df, threshold = .6)
 
 test_that("mappings work", {
   key <- mapping_key(prt)
-  expect_is(key, "tbl")
+  expect_s3_class(key, "tbl")
   expect_length(key, 4)
   expect_equal(nrow(key), ncol(partition_scores(prt)))
 
   long_key <- unnest_mappings(prt)
-  expect_is(long_key, "tbl")
+  expect_s3_class(long_key, "tbl")
   expect_length(long_key, 4)
   expect_equal(nrow(long_key), ncol(df))
   expect_equal(tidyr::unnest(key, cols = c(mapping, indices)), long_key)
@@ -21,13 +21,13 @@ test_that("mappings work", {
   expect_equal(length(gnames), length(gind))
   expect_equal(length(gnames), nrow(key))
   expect_equal(length(unlist(gnames)), nrow(long_key))
-  expect_is(gnames[[1]], "character")
-  expect_is(gind[[1]], "integer")
+  expect_type(gnames[[1]], "character")
+  expect_type(gind[[1]], "integer")
 })
 
 
 test_that("reduced scores work", {
   scores <- partition_scores(prt)
-  expect_is(scores, "tbl")
+  expect_s3_class(scores, "tbl")
   expect_equal(nrow(scores), nrow(df))
 })

--- a/tests/testthat/test-mappings-and-scores-work.R
+++ b/tests/testthat/test-mappings-and-scores-work.R
@@ -1,4 +1,3 @@
-context("test-mappings-and-scores-work")
 set.seed(1234)
 prt <- partition(df, threshold = .6)
 

--- a/tests/testthat/test-misc-partitioner-arguments.R
+++ b/tests/testthat/test-misc-partitioner-arguments.R
@@ -21,7 +21,7 @@ test_that("accelerated functions return correctly", {
 })
 
 test_that("spearman distance works", {
-  expect_is(partition(df8, .65, partitioner = part_icc(spearman = TRUE)), "partition")
+  expect_s3_class(partition(df8, .65, partitioner = part_icc(spearman = TRUE)), "partition")
 })
 
 test_that("linear and binary searches find the same partition", {
@@ -43,7 +43,7 @@ test_that("init k searches find the same partition", {
   expect_identical_partition(search_k, above_k)
 
   search_back <- partition(df8, .0001, partitioner = part_kmeans(search = "linear", init_k = 3))
-  expect_is(search_back, "partition")
+  expect_s3_class(search_back, "partition")
 })
 
 test_that("r kmeans algorithms work", {
@@ -52,8 +52,8 @@ test_that("r kmeans algorithms work", {
   k_f <- partition(df8, .65, partitioner = part_kmeans(algorithm = "Forgy"))
   k_m <- partition(df8, .65, partitioner = part_kmeans(algorithm = "MacQueen"))
 
-  expect_is(k_hw, "partition")
-  expect_is(k_l, "partition")
-  expect_is(k_f, "partition")
-  expect_is(k_m, "partition")
+  expect_s3_class(k_hw, "partition")
+  expect_s3_class(k_l, "partition")
+  expect_s3_class(k_f, "partition")
+  expect_s3_class(k_m, "partition")
 })

--- a/tests/testthat/test-misc-partitioner-arguments.R
+++ b/tests/testthat/test-misc-partitioner-arguments.R
@@ -1,4 +1,3 @@
-context("test-misc-partitioner-arguments")
 set.seed(1234)
 
 expect_identical_partition <- function(.x, .y, same_partitioner = TRUE) {

--- a/tests/testthat/test-misc-partitioner-arguments.R
+++ b/tests/testthat/test-misc-partitioner-arguments.R
@@ -5,7 +5,7 @@ expect_identical_partition <- function(.x, .y, same_partitioner = TRUE) {
   expect_identical(.x$mapping_key, .y$mapping_key)
   expect_identical(.x$threshold, .y$threshold)
   if (same_partitioner) {
-    expect_equal(.x$partitioner, .y$partitioner)
+    expect_equal(.x$partitioner, .y$partitioner, ignore_function_env = TRUE)
   } else {
     expect_failure(expect_identical(.x$partitioner, .y$partitioner))
   }

--- a/tests/testthat/test-partition-objects-are-well-shaped.R
+++ b/tests/testthat/test-partition-objects-are-well-shaped.R
@@ -1,4 +1,3 @@
-context("test-partition-objects-are-well-shaped")
 set.seed(123)
 
 prt <- partition(df, threshold = .6)

--- a/tests/testthat/test-partition-objects-are-well-shaped.R
+++ b/tests/testthat/test-partition-objects-are-well-shaped.R
@@ -28,13 +28,13 @@ test_that("partition object is returning correctly", {
   expect_equal(names(map_key), c("variable", "mapping", "information", "indices"))
   expect_type(map_key[["variable"]], "character")
   expect_type(map_key[["mapping"]], "list")
-  expect_type(map_key[["information"]], "numeric")
+  expect_type(map_key[["information"]], "double")
   expect_type(map_key[["indices"]], "list")
   expect_true(all_numeric)
 
   # threshold
   expect_equal(threshold, .6)
-  expect_type(threshold, "numeric")
+  expect_type(threshold, "double")
 
   # partitioner
   expect_s3_class(prtnr, "partitioner")

--- a/tests/testthat/test-partition-objects-are-well-shaped.R
+++ b/tests/testthat/test-partition-objects-are-well-shaped.R
@@ -16,25 +16,25 @@ test_that("partition object is returning correctly", {
   expect_equal(names(prt), c("reduced_data", "mapping_key", "threshold", "partitioner"))
 
   # reduced data
-  expect_is(reduced_data, c("tbl_df", "tbl", "data.frame"))
+  expect_s3_class(reduced_data, c("tbl_df", "tbl", "data.frame"))
   expect_named(reduced_data)
   expect_equal(names(reduced_data), c("block1_x3", "block1_x5", "reduced_var_1"))
   all_numeric <- all(purrr::map_chr(reduced_data, class) == "numeric")
   expect_true(all_numeric)
 
   # mapping key
-  expect_is(map_key, c("tbl_df", "tbl", "data.frame"))
+  expect_s3_class(map_key, c("tbl_df", "tbl", "data.frame"))
   expect_named(map_key)
   expect_equal(names(map_key), c("variable", "mapping", "information", "indices"))
-  expect_is(map_key[["variable"]], "character")
-  expect_is(map_key[["mapping"]], "list")
-  expect_is(map_key[["information"]], "numeric")
-  expect_is(map_key[["indices"]], "list")
+  expect_type(map_key[["variable"]], "character")
+  expect_type(map_key[["mapping"]], "list")
+  expect_type(map_key[["information"]], "numeric")
+  expect_type(map_key[["indices"]], "list")
   expect_true(all_numeric)
 
   # threshold
   expect_equal(threshold, .6)
-  expect_is(threshold, "numeric")
+  expect_type(threshold, "numeric")
 
   # partitioner
   expect_s3_class(prtnr, "partitioner")

--- a/tests/testthat/test-partitioners-helpers-work.R
+++ b/tests/testthat/test-partitioners-helpers-work.R
@@ -1,4 +1,3 @@
-context("test-partitioners-helpers-work")
 set.seed(1234)
 df <- simulate_block_data(5, lower_corr = .6, upper_corr = .65, n = 100)
 

--- a/tests/testthat/test-partitioners-helpers-work.R
+++ b/tests/testthat/test-partitioners-helpers-work.R
@@ -1,6 +1,17 @@
 set.seed(1234)
 df <- simulate_block_data(5, lower_corr = .6, upper_corr = .65, n = 100)
 
+test_that("simulate_block_data() works", {
+  blocks <- c(3, 4, 5)
+  n <- 100
+  expect_silent(df2 <- simulate_block_data(blocks, lower_corr = .4, upper_corr = .6, n = n))
+  expect_s3_class(df2, "tbl")
+  expect_length(df2, sum(blocks))
+  expect_equal(nrow(df2), n)
+})
+
+df <- simulate_block_data(5, lower_corr = .6, upper_corr = .65, n = 100)
+
 test_that("all partitioners are partitioners", {
   expect_s3_class(part_icc(), "partitioner")
   expect_s3_class(part_kmeans(), "partitioner")

--- a/tests/testthat/test-partitioners-reduce-correctly.R
+++ b/tests/testthat/test-partitioners-reduce-correctly.R
@@ -1,4 +1,3 @@
-context("test-partitioners-reduce-correctly")
 set.seed(1234)
 
 expect_mapping_names <- function(nms, .prt) {

--- a/tests/testthat/test-permutations-return-correctly.R
+++ b/tests/testthat/test-permutations-return-correctly.R
@@ -2,7 +2,7 @@ set.seed(1234)
 
 test_that("permuted dfs are correct", {
   pdf <- permute_df(df)
-  expect_is(pdf, "data.frame")
+  expect_s3_class(pdf, "data.frame")
   expect_length(pdf, length(df))
   expect_equal(nrow(pdf), nrow(df))
   expect_equal(names(pdf), names(df))
@@ -11,7 +11,7 @@ test_that("permuted dfs are correct", {
 mapped_part <- map_partition(df)
 
 test_that("mapped partitions are correct", {
-  expect_is(mapped_part, "tbl")
+  expect_s3_class(mapped_part, "tbl")
   expect_length(mapped_part, 5)
   nms <- c("target_info", "observed_info", "nclusters", "nreduced", "partition")
   expect_equal(names(mapped_part), nms)
@@ -20,7 +20,7 @@ test_that("mapped partitions are correct", {
 
 test_that("permutations are correct", {
   perms <- test_permutation(df, nperm = 2)
-  expect_is(perms, "tbl")
+  expect_s3_class(perms, "tbl")
   expect_length(perms, 9)
   expect_equal(nrow(perms), 6)
   expect_equal(names(perms)[1:5], names(mapped_part))

--- a/tests/testthat/test-permutations-return-correctly.R
+++ b/tests/testthat/test-permutations-return-correctly.R
@@ -1,4 +1,3 @@
-context("test-permutations-return-correctly")
 set.seed(1234)
 
 test_that("permuted dfs are correct", {

--- a/tests/testthat/test-plots-are-plotting.R
+++ b/tests/testthat/test-plots-are-plotting.R
@@ -1,4 +1,3 @@
-context("test-plots-are-plotting")
 set.seed(1234)
 perms <- test_permutation(df, nperm = 2)
 

--- a/tests/testthat/test-plots-are-plotting.R
+++ b/tests/testthat/test-plots-are-plotting.R
@@ -6,25 +6,25 @@ test_that("plots are plotting", {
   g2 <- plot_permutation(perms, .plot = "nclusters")
   g3 <- plot_permutation(perms, .plot = "nreduced")
 
-  expect_is(ggplot2::ggplot_build(g1), "ggplot_built")
-  expect_is(ggplot2::ggplot_build(g2), "ggplot_built")
-  expect_is(ggplot2::ggplot_build(g3), "ggplot_built")
+  expect_s3_class(ggplot2::ggplot_build(g1), "ggplot_built")
+  expect_s3_class(ggplot2::ggplot_build(g2), "ggplot_built")
+  expect_s3_class(ggplot2::ggplot_build(g3), "ggplot_built")
 
   g4 <- plot_information(perms$partition[[6]])
   g5 <- plot_ncluster(perms$partition[[6]])
 
-  expect_is(ggplot2::ggplot_build(g4), "ggplot_built")
-  expect_is(ggplot2::ggplot_build(g5), "ggplot_built")
+  expect_s3_class(ggplot2::ggplot_build(g4), "ggplot_built")
+  expect_s3_class(ggplot2::ggplot_build(g5), "ggplot_built")
 
   g6 <- plot_information(perms)
   g7 <- plot_ncluster(perms)
 
-  expect_is(ggplot2::ggplot_build(g6), "ggplot_built")
-  expect_is(ggplot2::ggplot_build(g7), "ggplot_built")
+  expect_s3_class(ggplot2::ggplot_build(g6), "ggplot_built")
+  expect_s3_class(ggplot2::ggplot_build(g7), "ggplot_built")
 
   g8 <- plot_area_clusters(df, information = seq(0.1, 0.5, length.out = 10))
-  expect_is(ggplot2::ggplot_build(g8), "ggplot_built")
+  expect_s3_class(ggplot2::ggplot_build(g8), "ggplot_built")
 
   g9 <- plot_stacked_area_clusters(df, information = seq(0.1, 0.5, length.out = 10))
-  expect_is(ggplot2::ggplot_build(g8), "ggplot_built")
+  expect_s3_class(ggplot2::ggplot_build(g8), "ggplot_built")
 })


### PR DESCRIPTION
This PR updates partition to use testthat edition 3. CRAN contacted me that upcoming changes in R-devel resulted in test failures; these relate to environment checking in the new version. testthat 3 evades this issue by using waldo. This change is required to maintain partition on CRAN