### PR TITLE
Fix issue with not sorting columns for reduced vars

### DIFF
--- a/R/super_partition.R
+++ b/R/super_partition.R
@@ -293,8 +293,8 @@ super_partition <- function(full_data,
 
   # sort reduced var rows
   reduced_var_rows <- grep(x, part_master$mapping_key$variable)
-  part_master$mapping_key$variable[reduced_var_rows] <-
-    part_master$mapping_key$variable[reduced_var_rows][gtools::mixedorder(part_master$mapping_key$variable[reduced_var_rows])]
+  part_master$mapping_key[reduced_var_rows, ] <-
+    part_master$mapping_key[gtools::mixedorder(part_master$mapping_key$variable[reduced_var_rows]), ]
 
   # match names between mapping_key and reduced_data
   part_master$reduced_data <- part_master$reduced_data[, match(part_master$mapping_key$variable, colnames(part_master$reduced_data))]

--- a/R/super_partition.R
+++ b/R/super_partition.R
@@ -293,8 +293,10 @@ super_partition <- function(full_data,
 
   # sort reduced var rows
   reduced_var_rows <- grep(x, part_master$mapping_key$variable)
-  part_master$mapping_key[reduced_var_rows, ] <-
-    part_master$mapping_key[gtools::mixedorder(part_master$mapping_key$variable[reduced_var_rows]), ]
+  new_order        <- gtools::mixedsort(part_master$mapping_key$variable[reduced_var_rows])
+  small            <- part_master$mapping_key[reduced_var_rows, ]
+  small            <- small[match(new_order, small$variable), ]
+  part_master$mapping_key[reduced_var_rows, ] <- small
 
   # match names between mapping_key and reduced_data
   part_master$reduced_data <- part_master$reduced_data[, match(part_master$mapping_key$variable, colnames(part_master$reduced_data))]

--- a/tests/testthat/test-super-partition-objects.R
+++ b/tests/testthat/test-super-partition-objects.R
@@ -60,7 +60,7 @@ test_that("dimensions are consistent", {
   expect_equal(nrow(map_key), 4)
   expect_equal(nrow(reduced_map), 3)
   map_lengths <- purrr::map_int(map_key[["mapping"]], length)
-  expect_true(all(map_lengths == c(1, 2, 2, 3)))
+  expect_true(all(map_lengths == c(1, 3, 2, 2)))
   index_lengths <- purrr::map_int(map_key[["indices"]], length)
   expect_true(all(index_lengths == map_lengths))
 


### PR DESCRIPTION
Hi Malcolm,

We found a bug in the last step of the sorting process. Previously, the code was resorting rows without resorting the columns, leading to problems with indices not matching. This fixes that.

Thanks,
K