### PR TITLE
simplify images on cran

### DIFF
--- a/vignettes/extending-partition.Rmd
+++ b/vignettes/extending-partition.Rmd
@@ -10,13 +10,19 @@ vignette: >
 ---
 
 ```{r setup, include = FALSE}
+if (identical(Sys.getenv("IN_PKGDOWN"), "true")) {
+  dpi <- 320
+} else {
+  dpi <- 72
+}
+
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   fig.width = 7,
   fig.height = 5,
   fig.align = "center",
-  fig.dpi = 320,
+  fig.dpi = dpi,
   warning = FALSE,
   message = FALSE
 )

--- a/vignettes/introduction-to-partition.Rmd
+++ b/vignettes/introduction-to-partition.Rmd
@@ -39,13 +39,19 @@ vignette: >
 ---
 
 ```{r setup, include = FALSE}
+if (identical(Sys.getenv("IN_PKGDOWN"), "true")) {
+  dpi <- 320
+} else {
+  dpi <- 72
+}
+
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   fig.width = 7,
   fig.height = 5,
   fig.align = "center",
-  fig.dpi = 320,
+  fig.dpi = dpi,
   warning = FALSE,
   message = FALSE
 )


### PR DESCRIPTION
Only use high DPI images on pkgdown site to reduce size of CRAN build