### PR TITLE
Improve pc1 usage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,4 +62,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -146,12 +146,16 @@ measure_min_icc <- function(.partition_step, search_method = c("binary", "linear
   .partition_step
 }
 
-#' Measure the information loss of reduction using the variance explained
+#' Measure the information loss of reduction using the variance explained.
 #'
 #' @template describe_metric
 #'
-#' @description `measure_variance_explained()` assesses information loss by calculating the
-#'   variance explained by the first component of a principal components analysis.
+#' @description `measure_variance_explained()` assesses information loss by
+#'   calculating the variance explained by the first component of a principal
+#'   components analysis. Because the PCA calculates the components and the
+#'   variance explained at the same time, if the reducer is
+#'   `reduce_first_component()`, then `measure_variance_explained()` will store
+#'   the first component for later use to avoid recalculation.
 #'
 #' @template partition_step
 #' @export

--- a/R/reducers.R
+++ b/R/reducers.R
@@ -75,7 +75,12 @@ reduce_kmeans <- function(.partition_step, search = c("binary", "linear"), n_hit
 #' @template describe_reducer
 #'
 #' @description `reduce_first_component()` returns the first component from the
-#'   principal components analysis of the target variables.
+#'   principal components analysis of the target variables. Because the PCA
+#'   calculates the components and the variance explained at the same time, if
+#'   the metric is `measure_variance_explained()`, that function will store the
+#'   first component for use in `reduce_first_component()` to avoid
+#'   recalculation. If the partitioner uses a different metric, the first
+#'   component will be calculated by `reduce_first_component()`.
 #'
 #' @template partition_step
 #' @export

--- a/R/reducers.R
+++ b/R/reducers.R
@@ -81,7 +81,27 @@ reduce_kmeans <- function(.partition_step, search = c("binary", "linear"), n_hit
 #' @export
 reduce_first_component <- function(.partition_step) {
   # this function uses the first PC, which is fit at the same time as variance
-  # explained, so no need to pass a function. Just process it.
+  # explained, so we don't need to calculate it if `measure_variance_explained()`
+  # already did
+  uses_variance_explained <- is_same_function(
+    .partition_step$partitioner$measure,
+    measure_variance_explained
+  )
+  # if we didn't call `measure_variance_explained()`,
+  # calculate the first component
+  if (!uses_variance_explained) {
+    composite_variables <- pull_composite_variables(.partition_step)
+    target_data <- .partition_step$.df[, composite_variables, drop = FALSE]
+
+    pca1 <- pca_c(as.matrix(na.omit(target_data)))
+    .partition_step$new_variable <- as.numeric(pca1[["pc1"]])
+    missing_row <- is_missing_rowwise(target_data)
+    #  return same number of rows as original data with missing values where not complete
+    if (any(missing_row)) .partition_step$new_variable <- fill_in_missing(.partition_step$new_variable, missing_row)
+  }
+
+  # We already calculated the new variable, so no need to pass a function.
+  # Just process it.
   reduce_cluster(.partition_step, NULL)
 }
 

--- a/man/measure_variance_explained.Rd
+++ b/man/measure_variance_explained.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/metrics.R
 \name{measure_variance_explained}
 \alias{measure_variance_explained}
-\title{Measure the information loss of reduction using the variance explained}
+\title{Measure the information loss of reduction using the variance explained.}
 \usage{
 measure_variance_explained(.partition_step)
 }
@@ -18,8 +18,12 @@ lost for a given reduction in the data. reduce.  \code{\link[=as_measure]{as_mea
 helper function to create new metrics to be used in \code{partitioner}s.
 \code{partitioner}s can be created with \code{\link[=as_partitioner]{as_partitioner()}}.
 
-\code{measure_variance_explained()} assesses information loss by calculating the
-variance explained by the first component of a principal components analysis.
+\code{measure_variance_explained()} assesses information loss by
+calculating the variance explained by the first component of a principal
+components analysis. Because the PCA calculates the components and the
+variance explained at the same time, if the reducer is
+\code{reduce_first_component()}, then \code{measure_variance_explained()} will store
+the first component for later use to avoid recalculation.
 }
 \seealso{
 Other metrics: 

--- a/man/reduce_first_component.Rd
+++ b/man/reduce_first_component.Rd
@@ -19,7 +19,12 @@ reducers to be used in \code{partitioner}s. \code{partitioner}s can be created w
 \code{\link[=as_partitioner]{as_partitioner()}}.
 
 \code{reduce_first_component()} returns the first component from the
-principal components analysis of the target variables.
+principal components analysis of the target variables. Because the PCA
+calculates the components and the variance explained at the same time, if
+the metric is \code{measure_variance_explained()}, that function will store the
+first component for use in \code{reduce_first_component()} to avoid
+recalculation. If the partitioner uses a different metric, the first
+component will be calculated by \code{reduce_first_component()}.
 }
 \seealso{
 Other reducers: 

--- a/tests/testthat/test-partitioners-reduce-correctly.R
+++ b/tests/testthat/test-partitioners-reduce-correctly.R
@@ -100,9 +100,11 @@ test_that("reduce_first_component() works without measure_variance_explained()",
     reduce = reduce_first_component
   )
 
-  prt <- partition(df, threshold = .7, partitioner = part_custom)
+  prt <- partition(df, threshold = .6, partitioner = part_custom)
 
   expect_reduction(prt)
+  expect_mapping_names(c("block1_x3", "block1_x5", "reduced_var_1"), prt)
+  expect_mapping_info(c(1, 1, 0.6), prt)
 })
 
 test_that("part_stdmi() reduces correctly, high threshold", {

--- a/tests/testthat/test-partitioners-reduce-correctly.R
+++ b/tests/testthat/test-partitioners-reduce-correctly.R
@@ -15,6 +15,11 @@ expect_no_reduction <- function(.prt, .df) {
   expect_equal(.prt[["mapping_key"]][["variable"]], names(.df))
 }
 
+expect_reduction <- function(.prt) {
+  all_1 <- all(.prt[["mapping_key"]][["information"]] == 1)
+  expect_false(all_1)
+}
+
 test_that("part_icc() reduces correctly, high threshold", {
   prt <- expect_silent(partition(df, threshold = .6))
   expect_mapping_names(c("block1_x3", "block1_x5", "reduced_var_1"), prt)
@@ -87,6 +92,17 @@ test_that("part_pc1() reduces correctly, low threshold", {
 test_that("part_pc1() reduces correctly, independent data", {
   ind_prt <- partition(ind_df, threshold = .8, partitioner = part_pc1())
   expect_no_reduction(ind_prt, ind_df)
+})
+
+test_that("reduce_first_component() works without measure_variance_explained()", {
+  part_custom <- replace_partitioner(
+    part_icc,
+    reduce = reduce_first_component
+  )
+
+  prt <- partition(df, threshold = .7, partitioner = part_custom)
+
+  expect_reduction(prt)
 })
 
 test_that("part_stdmi() reduces correctly, high threshold", {


### PR DESCRIPTION
This PR:
* Allows `reduce_first_component()` to operate independently of `measure_variance_explained()`
* Improves the documentation about their relationship and how it improves computational efficiency

Closes #40 

